### PR TITLE
Cotutelle form and display fixes

### DIFF
--- a/contrib/forms/cotutelle.py
+++ b/contrib/forms/cotutelle.py
@@ -43,6 +43,9 @@ class DoctorateAdmissionCotutelleForm(forms.Form):
     motivation = forms.CharField(
         label=_("Cotutelle motivation"),
         required=False,
+        widget=forms.Textarea(attrs={
+            'rows': 2,
+        }),
     )
     institution = forms.CharField(
         label=_("Cotutelle institution"),
@@ -59,7 +62,7 @@ class DoctorateAdmissionCotutelleForm(forms.Form):
         max_files=1,
     )
     autres_documents = FileUploadField(
-        label=_("Other documents"),
+        label=_("Other documents concerning cotutelle"),
         required=False,
     )
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -629,7 +629,7 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
-msgid "Other documents"
+msgid "Other documents concerning cotutelle"
 msgstr ""
 
 msgid "Other education, to specify"

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -668,8 +668,8 @@ msgstr "Pays organisateur"
 msgid "Other"
 msgstr "Autre"
 
-msgid "Other documents"
-msgstr "Autres documents"
+msgid "Other documents concerning cotutelle"
+msgstr "Autres documents relatifs à la cotutelle"
 
 msgid "Other education, to specify"
 msgstr "Autre éducation, précisez"

--- a/templates/admission/doctorate/detail_cotutelle.html
+++ b/templates/admission/doctorate/detail_cotutelle.html
@@ -29,11 +29,11 @@
         {% if cotutelle.cotutelle is None %}
             {% trans "Cotutelle is not defined yet" %}
         {% elif cotutelle.cotutelle %}
-            {% field_data _("Motivation") cotutelle.motivation %}
+            {% field_data _("Motivation") cotutelle.motivation|linebreaks %}
             {% field_data _("Institution") cotutelle.institution %}
             {% field_data _("Opening request") cotutelle.demande_ouverture %}
             {% field_data _("Convention") cotutelle.convention %}
-            {% field_data _("Other documents") cotutelle.autres_documents %}
+            {% field_data _("Other documents concerning cotutelle") cotutelle.autres_documents %}
         {% else %}
             {% trans "No cotutelle" %}
         {% endif %}


### PR DESCRIPTION
 
- Le champ "Motivation de la cotutelle" doit être de type textarea. Attention à préserver les retours chariots à l'affichage.
- Libellés Confluence à respecter  : Autres documents relatifs à la cotutelle
 