### PR TITLE
WIP

### DIFF
--- a/contrib/forms/__init__.py
+++ b/contrib/forms/__init__.py
@@ -236,10 +236,20 @@ RadioBooleanField = partial(
 )
 
 
+class AdmissionFileBoundField(forms.BoundField):
+    @property
+    def bound_css_class(self):
+        if self.value() in self.field.empty_values:
+            return 'empty-file-upload'
+
+
 class AdmissionFileUploadField(FileUploadField):
     def __init__(self, **kwargs):
         kwargs.setdefault('mimetypes', DEFAULT_MIME_TYPES)
         super().__init__(**kwargs)
+
+    def get_bound_field(self, form, field_name):
+        return AdmissionFileBoundField(form=form, field=self, name=field_name)
 
 
 def get_example_text(example: str):

--- a/static/admission/admission.css
+++ b/static/admission/admission.css
@@ -394,3 +394,7 @@ body, html {
 .mt-1 {
   margin-top: 1em;
 }
+
+.required_field.empty-file-upload label, .required_field .empty-file-upload:first-child label {
+  color: #a94442;
+}


### PR DESCRIPTION
Modification du render dans osis-portal :

```python
from bootstrap3.renderers import FieldRenderer
from bootstrap3.utils import add_css_class


class OsisFieldRenderer(FieldRenderer):
    # 1ère version
    def __init__(self, field, *args, **kwargs):
        if not kwargs.get('success_class'):
            kwargs['success_class'] = getattr(field, 'success_class', '')
        
        super().__init__(field, *args, **kwargs)

    # 2ème version
    def get_form_group_class(self):
        form_group_class = super().get_form_group_class()
        if self.field.value() in self.field.field.empty_values:
            form_group_class = add_css_class(form_group_class, 'empty-field')
        return form_group_class

```