### PR TITLE
[hotfix/OS-824 => DEV] Front-office: Curriculum > Une activité non-académique : Remplacement de l_intitulé de l_attestation pour le type _Autre_ (alias problématique du _ci-dessus_)

### DIFF
--- a/contrib/enums/curriculum.py
+++ b/contrib/enums/curriculum.py
@@ -6,7 +6,7 @@
 #    The core business involves the administration of students, teachers,
 #    courses, programs and so on.
 #
-#    Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#    Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -99,5 +99,7 @@ CURRICULUM_ACTIVITY_LABEL = {
     ),
     ActivityType.VOLUNTEERING.name: _('Certificate, with dates, justifying your volunteering activities'),
     ActivityType.WORK.name: _('Proof of employment from the employer, with dates, justifying the period in question'),
-    ActivityType.OTHER.name: _('Post-dated certificate justifying your activity mentioned above'),
+    ActivityType.OTHER.name: _(
+        'Certificate justifying your activity, mentioning this activity, for the period concerned'
+    ),
 }

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -637,6 +637,11 @@ msgstr "Certificate"
 msgid "Certificate for children of staff"
 msgstr ""
 
+msgid ""
+"Certificate justifying your activity, mentioning this activity, for the "
+"period concerned"
+msgstr ""
+
 msgid "Certificate of achievement"
 msgstr ""
 
@@ -2392,9 +2397,6 @@ msgid ""
 "Please select the assessment system used by the institution where you "
 "studied. The assessment system is usually indicated <strong>on your "
 "transcripts or diploma supplements</strong>."
-msgstr ""
-
-msgid "Post-dated certificate justifying your activity mentioned above"
 msgstr ""
 
 msgid "Postal address"

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -734,6 +734,13 @@ msgstr "Certificat et attestation"
 msgid "Certificate for children of staff"
 msgstr "Attestation enfant du personnel"
 
+msgid ""
+"Certificate justifying your activity, mentioning this activity, for the "
+"period concerned"
+msgstr ""
+"Attestation justifiant votre activité, mentionnant cette activité, pour la "
+"période concernée"
+
 msgid "Certificate of achievement"
 msgstr "Attestation de réussite"
 
@@ -2724,9 +2731,6 @@ msgstr ""
 "dans lequel vous avez suivi vos études. Le système d'évaluation est "
 "généralement mentionné <strong>sur vos relevés de notes ou sur vos "
 "suppléments de diplôme</strong>."
-
-msgid "Post-dated certificate justifying your activity mentioned above"
-msgstr "Attestation postdatée justifiant votre activité mentionnée ci-dessus"
 
 msgid "Postal address"
 msgstr "Adresse de correspondance"


### PR DESCRIPTION
Pull request automatique de hotfix/OS-824 vers DEV