### PR TITLE
[WIP] [hotfix/OS-932 => DEV] Front-office: Onglet confirmation > Message _Erreur inattendue_ affiché alors que les conditions d_accès sont non-remplies et que le candidat a la possibilité d_y remédier (ex : demande L-ESPO24-0000.3385)

### DIFF
--- a/contrib/views/common/form_tabs/confirm_submit.py
+++ b/contrib/views/common/form_tabs/confirm_submit.py
@@ -6,7 +6,7 @@
 #  The core business involves the administration of students, teachers,
 #  courses, programs and so on.
 #
-#  Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+#  Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -111,6 +111,7 @@ class AdmissionConfirmSubmitFormView(LoadDossierViewMixin, WebServiceFormMixin, 
                     errors_by_tab[tab_name]['errors'][error['status_code']] = []
                 errors_by_tab[tab_name]['errors'][error['status_code']].append(error['detail'])
             context['missing_confirmation_conditions'] = errors_by_tab
+            context['missing_confirmations_conditions_number'] = len(self.confirmation_conditions['errors'])
 
         context['access_conditions_url'] = self.confirmation_conditions.get('access_conditions_url')
         context['pool_start_date'] = self.confirmation_conditions.get('pool_start_date')

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -3228,7 +3228,9 @@ msgid ""
 msgstr ""
 
 #, python-format
-msgid "Unexpected error, please <a href=\"%(url)s\">contact service desk</a>."
+msgid ""
+"Unexpected error, please <a href=\"%(url)s\" target=\"_blank\">contact "
+"service desk</a>."
 msgstr ""
 
 msgid "Unique business number"

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -3660,10 +3660,12 @@ msgstr ""
 "concernée"
 
 #, python-format
-msgid "Unexpected error, please <a href=\"%(url)s\">contact service desk</a>."
+msgid ""
+"Unexpected error, please <a href=\"%(url)s\" target=\"_blank\">contact "
+"service desk</a>."
 msgstr ""
-"Erreur inattendue, veuillez <a href=\"%(url)s\">contacter le service desk</"
-"a>."
+"Erreur inattendue, veuillez <a href=\"%(url)s\" target=\"_blank\">contacter "
+"le service desk</a>."
 
 msgid "Unique business number"
 msgstr "Numéro unique d'entreprise"

--- a/templates/admission/forms/confirm-submit.html
+++ b/templates/admission/forms/confirm-submit.html
@@ -8,7 +8,7 @@
   * The core business involves the administration of students, teachers,
   * courses, programs and so on.
   *
-  * Copyright (C) 2015-2023 Université catholique de Louvain (http://www.uclouvain.be)
+  * Copyright (C) 2015-2024 Université catholique de Louvain (http://www.uclouvain.be)
   *
   * This program is free software: you can redistribute it and/or modify
   * it under the terms of the GNU General Public License as published by
@@ -95,13 +95,13 @@
 
                       {# Pool non déterminé #}
                     {% elif error_code == 'ADMISSION-12' %}
-                      <li>
-                        {# TODO url #}
-                        <p>{% blocktrans with url="#" trimmed %}
-                          Unexpected error, please <a href="{{ url }}">contact service desk</a>.
-                        {% endblocktrans %}</p>
-                      </li>
-
+                      {% if missing_confirmations_conditions_number == 1 %}
+                        <li>
+                          <p>{% blocktrans trimmed with url="http://uclouvain.be/8282" %}
+                            Unexpected error, please <a href="{{ url }}" target="_blank">contact service desk</a>.
+                          {% endblocktrans %}</p>
+                        </li>
+                      {% endif %}
                       {# Conditions d'accès non remplies #}
                     {% elif error_code == 'ADMISSION-2' %}
                       <li>


### PR DESCRIPTION
Pull request automatique de hotfix/OS-932 vers DEV