### PR TITLE
[hotfix/OS-928 => QA] Front-office: Blocage d_expérience non-valide provenant d_une autre demande et donc non-modifiable par le candidat > Toutes les expériences venant d_EPC doivent être considérées valides par l_application

### DIFF
--- a/contrib/views/common/detail_tabs/curriculum_experiences.py
+++ b/contrib/views/common/detail_tabs/curriculum_experiences.py
@@ -221,4 +221,4 @@ def experience_can_be_updated(experience, context):
             training in ADMISSION_EDUCATION_TYPE_BY_ADMISSION_CONTEXT['continuing-education']
             for training in experience.valuated_from_trainings
         )
-    )
+    ) and not getattr(experience, 'external_id', None)  # ... and if the experience doesn't come from EPC

--- a/contrib/views/common/form_tabs/curriculum_experiences.py
+++ b/contrib/views/common/form_tabs/curriculum_experiences.py
@@ -166,7 +166,7 @@ class AdmissionCurriculumProfessionalExperienceFormView(AdmissionCurriculumFormE
         if self.experience_id:
             experience = self.professional_experience.to_dict()
 
-            if self.professional_experience.valuated_from_trainings:
+            if self.professional_experience.valuated_from_trainings or self.professional_experience.external_id:
                 raise PermissionDenied
 
             start_date = experience.pop('start_date')
@@ -197,7 +197,7 @@ class AdmissionCurriculumProfessionalExperienceDeleteView(AdmissionCurriculumFor
         context = super().get_context_data(**kwargs)
         context['experience'] = self.professional_experience
 
-        if self.professional_experience.valuated_from_trainings:
+        if self.professional_experience.valuated_from_trainings or self.professional_experience.external_id:
             raise PermissionDenied
 
         return context
@@ -224,7 +224,7 @@ class AdmissionCurriculumEducationalExperienceDeleteView(AdmissionCurriculumForm
 
         initialize_field_texts(self.person, [self.educational_experience], self.current_context)
 
-        if self.educational_experience.valuated_from_trainings:
+        if self.educational_experience.valuated_from_trainings or self.educational_experience.external_id:
             raise PermissionDenied
 
         context['experience'] = self.educational_experience

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/uclouvain/osis-admission-sdk.git@build-1.0.93
+git+https://github.com/uclouvain/osis-admission-sdk.git@build-1.0.95
 freezegun==1.4.0
 phonenumberslite==8.13.29

--- a/templates/admission/details/curriculum.html
+++ b/templates/admission/details/curriculum.html
@@ -273,7 +273,7 @@
                 <td><span>{{ professional_experience.type.value|enum_display:'ActivityType' }}</span></td>
                 <td class="action-container">
                   <div class="btn-toolbar" role="group">
-                    {% if form and not professional_experience.valuated_from_trainings %}
+                    {% if form and not professional_experience.valuated_from_trainings and not professional_experience.external_id %}
                       <a
                           href="{{ experience_update_url }}#curriculum-header"
                           class="btn btn-info"

--- a/tests/views/curriculum/mixin.py
+++ b/tests/views/curriculum/mixin.py
@@ -229,6 +229,7 @@ class MixinTestCase(TestCase):
             uuid=str(uuid.uuid4()),
             certificate=[cls.document_uuid],
             valuated_from_trainings=[],
+            external_id='',
         )
 
         cls.lite_professional_experience = CurriculumDetailsProfessionalExperiences._from_openapi_data(
@@ -238,6 +239,7 @@ class MixinTestCase(TestCase):
             start_date=cls.professional_experience.start_date,
             end_date=cls.professional_experience.start_date,
             valuated_from_trainings=[],
+            external_id='',
         )
 
         # Proposition

--- a/tests/views/curriculum/test_academic_experience.py
+++ b/tests/views/curriculum/test_academic_experience.py
@@ -160,6 +160,20 @@ class CurriculumAcademicExperienceDeleteTestCase(MixinTestCase):
 
         self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
 
+    def test_with_admission_on_delete_epc_experience_is_forbidden(self):
+        mock_retrieve = self.mock_person_api.return_value.retrieve_educational_experience_admission
+        mock_retrieve.return_value.external_id = 'EPC_1'
+
+        response = self.client.get(
+            resolve_url(
+                'admission:doctorate:update:curriculum:educational_delete',
+                pk=self.proposition.uuid,
+                experience_id=self.educational_experience.uuid,
+            )
+        )
+
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
 
 @freezegun.freeze_time('2023-01-01')
 class CurriculumAcademicExperienceFormTestCase(MixinTestCase):
@@ -374,6 +388,14 @@ class CurriculumAcademicExperienceFormTestCase(MixinTestCase):
         # Check the request
         self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
 
+    def test_with_admission_on_update_epc_experience_form_is_forbidden_with_doctorate(self):
+        self.mockapi.retrieve_educational_experience_admission.return_value.external_id = 'EPC_1'
+
+        response = self.client.get(self.admission_update_url)
+
+        # Check the request
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
     def test_with_admission_on_update_experience_form_is_initialized_with_doctorate_and_valuated_by_general(self):
         editable_fields = EDUCATIONAL_EXPERIENCE_DOCTORATE_FIELDS
         self.mockapi.retrieve_educational_experience_admission.return_value.valuated_from_trainings = [
@@ -454,6 +476,15 @@ class CurriculumAcademicExperienceFormTestCase(MixinTestCase):
         # Check the request
         self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
 
+    def test_with_admission_on_update_epc_experience_form_is_forbidden_with_general(self):
+        mock_retrieve_experience = self.mockapi.retrieve_educational_experience_general_education_admission
+        mock_retrieve_experience.return_value.external_id = 'EPC_1'
+
+        response = self.client.get(self.general_admission_update_url)
+
+        # Check the request
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
     def test_with_admission_on_update_experience_form_is_forbidden_with_general_and_valuated_by_general(self):
         mock_retrieve_experience = self.mockapi.retrieve_educational_experience_general_education_admission
         mock_retrieve_experience.return_value.valuated_from_trainings = [
@@ -526,6 +557,15 @@ class CurriculumAcademicExperienceFormTestCase(MixinTestCase):
         mock_retrieve_experience.return_value.valuated_from_trainings = [
             TypeFormation.DOCTORAT.name,
         ]
+
+        response = self.client.get(self.continuing_admission_update_url)
+
+        # Check the request
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
+    def test_with_admission_on_update_epc_experience_form_is_forbidden_with_continuing(self):
+        mock_retrieve_experience = self.mockapi.retrieve_educational_experience_continuing_education_admission
+        mock_retrieve_experience.return_value.external_id = 'EPC_1'
 
         response = self.client.get(self.continuing_admission_update_url)
 

--- a/tests/views/curriculum/test_non_academic_experience.py
+++ b/tests/views/curriculum/test_non_academic_experience.py
@@ -128,6 +128,7 @@ class CurriculumNonAcademicExperienceFormTestCase(MixinTestCase):
                 'activity': self.professional_experience.activity,
                 'uuid': self.professional_experience.uuid,
                 'valuated_from_trainings': ANY,
+                'external_id': '',
             },
         )
 

--- a/tests/views/curriculum/test_non_academic_experience.py
+++ b/tests/views/curriculum/test_non_academic_experience.py
@@ -587,7 +587,7 @@ class CurriculumNonAcademicExperienceFormTestCase(MixinTestCase):
             resolve_url(
                 self.admission_update_url,
                 pk=self.proposition.uuid,
-                experience_id=self.educational_experience.uuid,
+                experience_id=self.professional_experience.uuid,
             )
         )
 
@@ -597,7 +597,32 @@ class CurriculumNonAcademicExperienceFormTestCase(MixinTestCase):
             resolve_url(
                 self.admission_update_url,
                 pk=self.proposition.uuid,
-                experience_id=self.educational_experience.uuid,
+                experience_id=self.professional_experience.uuid,
+                data=self.all_form_data,
+            )
+        )
+
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
+    def test_with_admission_on_update_epc_experience_is_forbidden(self):
+        mock_retrieve = self.mock_person_api.return_value.retrieve_professional_experience_admission
+        mock_retrieve.return_value.external_id = 'EPC_1'
+
+        response = self.client.get(
+            resolve_url(
+                self.admission_update_url,
+                pk=self.proposition.uuid,
+                experience_id=self.professional_experience.uuid,
+            )
+        )
+
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
+        response = self.client.post(
+            resolve_url(
+                self.admission_update_url,
+                pk=self.proposition.uuid,
+                experience_id=self.professional_experience.uuid,
                 data=self.all_form_data,
             )
         )
@@ -696,7 +721,21 @@ class CurriculumNonAcademicExperienceDeleteTestCase(MixinTestCase):
             resolve_url(
                 'admission:doctorate:update:curriculum:professional_delete',
                 pk=self.proposition.uuid,
-                experience_id=self.educational_experience.uuid,
+                experience_id=self.professional_experience.uuid,
+            )
+        )
+
+        self.assertEqual(response.status_code, HTTP_403_FORBIDDEN)
+
+    def test_with_admission_on_delete_epc_experience_is_forbidden(self):
+        mock_retrieve = self.mock_person_api.return_value.retrieve_professional_experience_admission
+        mock_retrieve.return_value.external_id = 'EPC_1'
+
+        response = self.client.get(
+            resolve_url(
+                'admission:doctorate:update:curriculum:professional_delete',
+                pk=self.proposition.uuid,
+                experience_id=self.professional_experience.uuid,
             )
         )
 


### PR DESCRIPTION
- [x] https://github.com/uclouvain/osis-admission/pull/1150 must be merged first
- [x] a new sdk version must be generated and then used here.

Pull request automatique de hotfix/OS-928 vers QA