### PR TITLE
[hotfix/OS-1261 => MASTER] Front-office : Bandeau d_information pour inscription tardive > Date au format 30/11/2024 plutôt que 2024-10-30

### DIFF
--- a/contrib/views/mixins.py
+++ b/contrib/views/mixins.py
@@ -179,7 +179,7 @@ class LoadDossierViewMixin(LoadViewMixin):
                     "later than %(date)s. The admission panel reserves the right to accept or refuse this "
                     "late application."
                 )
-                % {'date': self.admission.date_fin_pot},
+                % {'date': self.admission.date_fin_pot.strftime('%d/%m/%Y')},
             )
         return context
 

--- a/tests/views/test_confirm_submit.py
+++ b/tests/views/test_confirm_submit.py
@@ -162,7 +162,7 @@ class ConfirmSubmitTestCase(TestCase):
                 "later than %(date)s. The admission panel reserves the right to accept or refuse this "
                 "late application."
             )
-            % {'date': date_fin},
+            % {'date': date_fin.strftime('%d/%m/%Y')},
         )
 
     def test_post_with_incomplete_elements_confirmation(self):


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1261 vers MASTER