### PR TITLE
[hotfix/OS-1386 => DEV] [V1.A] Front-office: Parcours antérieur > Curriculum : Retrait de la phrase informative concernant les activités non-académiques affichée lorsque le parcours antérieur est vide

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1982,10 +1982,7 @@ msgstr ""
 msgid "Please correct the errors below"
 msgstr ""
 
-#, python-format
-msgid ""
-"Please enter all academic courses you have attended. For non-academic "
-"activities, please enter all those that have taken place since %(date)s."
+msgid "Please enter all academic courses you have attended."
 msgstr ""
 
 msgid "Please enter your work email address"

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -2282,14 +2282,9 @@ msgstr "Merci de spécifier une valeur pour le champ suivant : {}"
 msgid "Please correct the errors below"
 msgstr "Veuillez corriger les erreurs ci-dessous"
 
-#, python-format
-msgid ""
-"Please enter all academic courses you have attended. For non-academic "
-"activities, please enter all those that have taken place since %(date)s."
-msgstr ""
-"Veuillez renseigner toutes les formations académiques que vous avez "
-"réalisées. Pour les activités non-académiques, veuillez encoder toutes "
-"celles qui ont eu lieu depuis %(date)s."
+msgid "Please enter all academic courses you have attended."
+msgstr "Veuillez renseigner toutes les formations académiques que vous avez "
+"réalisées."
 
 msgid "Please enter your work email address"
 msgstr "Veuillez encoder votre adresse e-mail-professionnelle"

--- a/templates/admission/details/curriculum.html
+++ b/templates/admission/details/curriculum.html
@@ -64,10 +64,7 @@
     </p>
   {% elif need_to_complete %}
     <p class="alert alert-info" role="alert">
-      {% blocktranslate trimmed with date=minimal_date|date:"YEAR_MONTH_FORMAT"|capfirst %}
-        Please enter all academic courses you have attended. For non-academic activities, please enter
-        all those that have taken place since {{ date }}.
-      {% endblocktranslate %}
+      {% translate 'Please enter all academic courses you have attended.' %}
     </p>
   {% elif not access_conditions_not_met %}
     <p class="alert alert-info" role="alert">


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1386 vers DEV