### PR TITLE
[hotfix/OS-1564 => QA] Front-office: Activités non-académiques venant d_EPC ET n_étant PAS _valorisées_ par une demande OSIS antérieure > Les champs non-vides sont pour l_instant ouverts à la modification

### DIFF
--- a/contrib/forms/curriculum.py
+++ b/contrib/forms/curriculum.py
@@ -235,7 +235,7 @@ class AdmissionCurriculumProfessionalExperienceForm(forms.Form):
             self.fields['certificate'].disabled = True
             self.fields['certificate'].widget = forms.MultipleHiddenInput()
 
-        if experience and experience.get('valuated_from_trainings'):
+        if experience and (experience.get('valuated_from_trainings') or experience.get('external_id')):
             self.disable_valuated_fields(experience['valuated_from_trainings'])
 
     class Media:


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1564 vers QA