### PR TITLE
[hotfix/OS-1626 => QA] Front-office: Candidats en médecine ou dentisterie > Bloquer l_envoi pour les candidats lorsque, pour l_année du pot calendrier retenu (ex UE diplôme belge 2025-26), la date courante ne se trouve pas dans une période d_envoi possible pour la médecine

### DIFF
--- a/contrib/views/common/form_tabs/training_choice.py
+++ b/contrib/views/common/form_tabs/training_choice.py
@@ -110,7 +110,8 @@ class AdmissionTrainingChoiceFormView(
         if self.is_on_create or self.is_general:
             # Some messages are displayed when we are outside of some specific enrolment periods
             specific_enrolment_periods = AdmissionPropositionService.retrieve_specific_enrolment_periods(
-                person=self.request.user.person
+                person=self.request.user.person,
+                year=self.admission.annee_calculee if self.is_general else None,
             )
             today_date = datetime.date.today()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/uclouvain/osis-admission-sdk.git@build-1.1.10
+git+https://github.com/uclouvain/osis-admission-sdk.git@build-1.1.11

--- a/services/proposition.py
+++ b/services/proposition.py
@@ -24,7 +24,7 @@
 #
 # ##############################################################################
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 import osis_admission_sdk
 from django.conf import settings
@@ -120,8 +120,9 @@ class AdmissionPropositionService(metaclass=ServiceMeta):
         return APIClient().retrieve_dashboard(**build_mandatory_auth_headers(person)).to_dict().get('links', {})
 
     @classmethod
-    def retrieve_specific_enrolment_periods(cls, person: Person):
-        return APIClient().retrieve_specific_enrolment_periods(**build_mandatory_auth_headers(person))
+    def retrieve_specific_enrolment_periods(cls, person: Person, year: Optional[int]):
+        kwargs = {'year': year} if year else {}
+        return APIClient().retrieve_specific_enrolment_periods(**kwargs, **build_mandatory_auth_headers(person))
 
     @classmethod
     def list_proposition_create_permissions(cls, person):

--- a/templates/admission/details/curriculum_educational_experience.html
+++ b/templates/admission/details/curriculum_educational_experience.html
@@ -186,7 +186,7 @@
                   {% field_data _('Rank in diploma') experience.rank_in_diploma %}
                 </div>
                 <div class="col-md-6">
-                  {% field_data _('(Expected) graduation date (signed diploma)') experience.expected_graduation_date|date:"m/Y" %}
+                  {% field_data _('(Expected) graduation date') experience.expected_graduation_date|date:"m/Y" %}
                 </div>
               </div>
               <div class="row">


### PR DESCRIPTION
Pull request automatique de hotfix/OS-1626 vers QA